### PR TITLE
css 최적화 과제

### DIFF
--- a/defer-css-unoptimized.html
+++ b/defer-css-unoptimized.html
@@ -4,7 +4,35 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Unoptimized</title>
-  <link rel="stylesheet" type="text/css" href="defer-css.css">
+  <style>
+    .accordion-btn {
+      width: 100%;
+      text-align: center;
+      font-size: 18px;
+      cursor: pointer;
+      color: #444;
+      background-color: #add8e6;
+      padding: 19px;
+      outline: none;
+      border: none;
+      border-radius: 2px;
+    }
+
+    .container {
+      display: none;
+      padding: 0 18px;
+      background-color: white;
+      overflow: hidden;
+    }
+
+    h1 {
+      word-spacing: 5px;
+      color: blue;
+      font-weight: bold;
+      text-align: center;
+    }
+  </style>
+  <link rel="preload" as="style" href="defer-css.css" onload="this.onload=null;this.rel='stylesheet'">
 </head>
 <body>
 

--- a/defer-css.css
+++ b/defer-css.css
@@ -1,26 +1,6 @@
 /* Copyright 2018 Google LLC. SPDX-License-Identifier: Apache-2.0 */
-.accordion-btn {
-  width: 100%;
-  text-align: center;
-  font-size: 18px;
-  cursor: pointer;
-  color: #444;
-  background-color: #add8e6;
-  padding: 19px;
-  outline: none;
-  border: none;
-  border-radius: 2px;
-}
-
 .accordion-btn:hover {
   background-color: #87cefa;
-}
-
-.container {
-  display: none;
-  padding: 0 18px;
-  background-color: white;
-  overflow: hidden;
 }
 
 p {
@@ -48,17 +28,4 @@ p {
   overflow: hidden;
   text-overflow: clip;
   color: #228b22;
-}
-
-h1 {
-  word-spacing: 5px;
-  color: blue;
-  font-weight: bold;
-  text-align: center;
-}
-
-h3 {
-  word-spacing: -5px;
-  background-color: #eee;
-  text-align: center;
 }


### PR DESCRIPTION
1. 개발자 도구의 css coverage를 확인하여 사용하지 않는 h3 style을 삭제했습니다.
2. 필수 css를 head 내부로 옮겼습니다. hover style과 유저의 클릭 액션 이후에 나타나는 paragraph 관련 style은 css 파일에 남겨두었습니다.
3. css 파일을 지연 로딩/적용했습니다.
<img width="834" alt="스크린샷 2022-01-31 오전 1 59 46" src="https://user-images.githubusercontent.com/36505122/151709498-27801d10-8544-4b4e-88fe-d237ac34a59a.png">
최적화 전에는 css 파일이 다운로드된 이후(상단의 빨간색 테두리 박스) Parse Stylesheet를 수행하고 렌더링이 되지만,
<img width="792" alt="스크린샷 2022-01-31 오전 2 02 23" src="https://user-images.githubusercontent.com/36505122/151709524-88d4e2fe-272d-4920-917c-f8b9f2ed052f.png">
최적화 후에는 HTLM 만으로(왼쪽 하단의 파란색 박스가 HTML parsing을 의미함) 이미 초기 렌더링이 완료됨을 확인했습니다.